### PR TITLE
Add option to include line breaks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,20 +77,22 @@ function parseStyleMap(styleMap) {
 }
 
 
-function extractRawText(input) {
+function extractRawText(input, options = {}) {
     return unzip.openZip(input)
         .then(docxReader.read)
         .then(function(documentResult) {
-            return documentResult.map(convertElementToRawText);
+            return documentResult.map(element => convertElementToRawText(element, options));
         });
 }
 
-function convertElementToRawText(element) {
+function convertElementToRawText(element, options) {
+    if(element.type === "break" && options.allowLineBreaks) return "\n"
+
     if (element.type === "text") {
         return element.value;
     } else {
         var tail = element.type === "paragraph" ? "\n\n" : "";
-        return (element.children || []).map(convertElementToRawText).join("") + tail;
+        return (element.children || []).map(element => convertElementToRawText(element, options)).join("") + tail;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mammoth-line-breaks",
+  "name": "mammoth",
   "version": "1.4.13",
   "author": "Michael Williamson <mike@zwobble.org>",
   "description": "Convert Word documents from docx to simple HTML and Markdown",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mammoth",
+  "name": "mammoth-line-breaks",
   "version": "1.4.13",
   "author": "Michael Williamson <mike@zwobble.org>",
   "description": "Convert Word documents from docx to simple HTML and Markdown",


### PR DESCRIPTION
Add option to include line breaks for the extractRawText method. Simply add an optional options object as a second argument with allowLineBreaks set to true and line breaks will get preserved. If options object is not included it will work as it originally did before. See attached screenshots for output with and without the option applied respectively
![image](https://user-images.githubusercontent.com/14264995/93488546-b8be1e80-f8c3-11ea-9486-93e3451fb694.png)
![image](https://user-images.githubusercontent.com/14264995/93488605-c96e9480-f8c3-11ea-86d2-a33fced77213.png)

![image](https://user-images.githubusercontent.com/14264995/93488711-e4410900-f8c3-11ea-808a-25e490e1594d.png)
![image](https://user-images.githubusercontent.com/14264995/93488991-397d1a80-f8c4-11ea-8333-b70674929d00.png)



